### PR TITLE
ignoring Apex email notifications setting

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -10,6 +10,7 @@ package.xml
 **/objectTranslations/**
 **/profiles/**
 **/settings/**
+**/apexemailnotifications/**
 
 # LWC configuration files
 **/jsconfig.json


### PR DESCRIPTION
Quick fix to stop the configurations for ApexEmailNotifications to be added to project. 